### PR TITLE
Updated 16.2

### DIFF
--- a/io.dbeaver.DBeaverCommunity.Client.pgsql.json
+++ b/io.dbeaver.DBeaverCommunity.Client.pgsql.json
@@ -23,7 +23,7 @@
           "only-arches": [
             "x86_64"
           ],
-          "url": "git://git.postgresql.org/git/postgresql.git",
+          "url": "https://git.postgresql.org/git/postgresql.git",
           "tag": "REL_16_2",
           "commit": "b78fa8547d02fc72ace679fb4d5289dccdbfc781"
         },

--- a/io.dbeaver.DBeaverCommunity.Client.pgsql.json
+++ b/io.dbeaver.DBeaverCommunity.Client.pgsql.json
@@ -2,7 +2,7 @@
   "app-id": "io.dbeaver.DBeaverCommunity.Client.pgsql",
   "runtime": "io.dbeaver.DBeaverCommunity",
   "runtime-version": "stable",
-  "sdk": "org.freedesktop.Sdk//19.08",
+  "sdk": "org.freedesktop.Sdk//23.08",
   "build-extension": true,
   "separate-locales": false,
   "appstream-compose": false,
@@ -24,8 +24,8 @@
             "x86_64"
           ],
           "url": "git://git.postgresql.org/git/postgresql.git",
-          "tag": "REL_12_2",
-          "commit": "45b88269a353ad93744772791feb6d01bc7e1e42"
+          "tag": "REL_16_2",
+          "commit": "b78fa8547d02fc72ace679fb4d5289dccdbfc781"
         },
         {         
           "type": "file",


### PR DESCRIPTION
This PR serves as a base update for the PostgreSQL client. It updates the SDK from 19.08 to 23.08 and PostgreSQL from 12.2 to 16.2 (which is the most up to date LTS version).